### PR TITLE
Add Formatters to category list

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "color": "#0000FF",
         "theme": "dark"
     },
+	"categories": ["Formatters"],
     "license": "MIT",
     "bugs": {
         "url": "https://github.com/aeschli/vscode-css-formatter/issues",


### PR DESCRIPTION
The Marketplace has introduce a new category called formatters for extensions that add formatting.
